### PR TITLE
Use EUIPrompt for validation messages

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -14,7 +14,6 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiText,
   EuiButtonEmpty,
   EuiLink,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { Ast } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
 import {
+  EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -389,58 +390,58 @@ export const InnerVisualizationWrapper = ({
 
   if (localState.configurationValidationError?.length) {
     let showExtraErrors = null;
+    let showExtraErrorsAction = null;
+
     if (localState.configurationValidationError.length > 1) {
       if (localState.expandError) {
         showExtraErrors = localState.configurationValidationError
           .slice(1)
           .map(({ longMessage }) => (
-            <EuiFlexItem
+            <p
               key={longMessage}
               className="eui-textBreakAll"
               data-test-subj="configuration-failure-error"
-              grow={false}
             >
               {longMessage}
-            </EuiFlexItem>
+            </p>
           ));
       } else {
-        showExtraErrors = (
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              onClick={() => {
-                setLocalState((prevState: WorkspaceState) => ({
-                  ...prevState,
-                  expandError: !prevState.expandError,
-                }));
-              }}
-              data-test-subj="configuration-failure-more-errors"
-            >
-              {i18n.translate('xpack.lens.editorFrame.configurationFailureMoreErrors', {
-                defaultMessage: ` +{errors} {errors, plural, one {error} other {errors}}`,
-                values: { errors: localState.configurationValidationError.length - 1 },
-              })}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
+        showExtraErrorsAction = (
+          <EuiButtonEmpty
+            onClick={() => {
+              setLocalState((prevState: WorkspaceState) => ({
+                ...prevState,
+                expandError: !prevState.expandError,
+              }));
+            }}
+            data-test-subj="configuration-failure-more-errors"
+          >
+            {i18n.translate('xpack.lens.editorFrame.configurationFailureMoreErrors', {
+              defaultMessage: ` +{errors} {errors, plural, one {error} other {errors}}`,
+              values: { errors: localState.configurationValidationError.length - 1 },
+            })}
+          </EuiButtonEmpty>
         );
       }
     }
 
     return (
-      <EuiFlexGroup
-        style={{ maxWidth: '100%', height: '100%' }}
-        alignItems="center"
-        data-test-subj="configuration-failure"
-      >
+      <EuiFlexGroup data-test-subj="configuration-failure">
         <EuiFlexItem>
-          <EuiFlexGroup alignItems="center" direction="column">
-            <EuiFlexItem>
-              <EuiIcon type="alert" size="xl" color="danger" />
-            </EuiFlexItem>
-            <EuiFlexItem className="eui-textBreakAll" data-test-subj="configuration-failure-error">
-              {localState.configurationValidationError[0].longMessage}
-            </EuiFlexItem>
-            {showExtraErrors}
-          </EuiFlexGroup>
+          <EuiEmptyPrompt
+            actions={showExtraErrorsAction}
+            body={
+              <>
+                <p className="eui-textBreakAll" data-test-subj="configuration-failure-error">
+                  {localState.configurationValidationError[0].longMessage}
+                </p>
+
+                {showExtraErrors}
+              </>
+            }
+            iconColor="danger"
+            iconType="alert"
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     );
@@ -448,20 +449,24 @@ export const InnerVisualizationWrapper = ({
 
   if (localState.expressionBuildError?.length) {
     return (
-      <EuiFlexGroup style={{ maxWidth: '100%' }} alignItems="center">
+      <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiFlexGroup alignItems="center" direction="column">
-            <EuiFlexItem>
-              <EuiIcon type="alert" size="xl" color="danger" />
-            </EuiFlexItem>
-            <EuiFlexItem data-test-subj="expression-failure">
-              <FormattedMessage
-                id="xpack.lens.editorFrame.expressionFailure"
-                defaultMessage="An error occurred in the expression"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>{localState.expressionBuildError[0].longMessage}</EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiEmptyPrompt
+            body={
+              <>
+                <p data-test-subj="expression-failure">
+                  <FormattedMessage
+                    id="xpack.lens.editorFrame.expressionFailure"
+                    defaultMessage="An error occurred in the expression"
+                  />
+                </p>
+
+                <p>{localState.expressionBuildError[0].longMessage}</p>
+              </>
+            }
+            iconColor="danger"
+            iconType="alert"
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     );
@@ -482,20 +487,11 @@ export const InnerVisualizationWrapper = ({
           const visibleErrorMessage = getOriginalRequestErrorMessage(error) || errorMessage;
 
           return (
-            <EuiFlexGroup style={{ maxWidth: '100%' }} alignItems="center">
+            <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiFlexGroup alignItems="center" direction="column">
-                  <EuiFlexItem>
-                    <EuiIcon type="alert" size="xl" color="danger" />
-                  </EuiFlexItem>
-                  <EuiFlexItem data-test-subj="expression-failure">
-                    <FormattedMessage
-                      id="xpack.lens.editorFrame.dataFailure"
-                      defaultMessage="An error occurred when loading data."
-                    />
-                  </EuiFlexItem>
-                  {visibleErrorMessage ? (
-                    <EuiFlexItem className="eui-textBreakAll" grow={false}>
+                <EuiEmptyPrompt
+                  actions={
+                    visibleErrorMessage ? (
                       <EuiButtonEmpty
                         onClick={() => {
                           setLocalState((prevState: WorkspaceState) => ({
@@ -508,11 +504,25 @@ export const InnerVisualizationWrapper = ({
                           defaultMessage: 'Show details of error',
                         })}
                       </EuiButtonEmpty>
+                    ) : null
+                  }
+                  body={
+                    <>
+                      <p data-test-subj="expression-failure">
+                        <FormattedMessage
+                          id="xpack.lens.editorFrame.dataFailure"
+                          defaultMessage="An error occurred when loading data."
+                        />
+                      </p>
 
-                      {localState.expandError ? visibleErrorMessage : null}
-                    </EuiFlexItem>
-                  ) : null}{' '}
-                </EuiFlexGroup>
+                      {localState.expandError ? (
+                        <p className="eui-textBreakAll">visibleErrorMessage</p>
+                      ) : null}
+                    </>
+                  }
+                  iconColor="danger"
+                  iconType="alert"
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           );


### PR DESCRIPTION
## Summary

Refactoring the validation layout.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
