### PR TITLE
Split datatable render function

### DIFF
--- a/x-pack/plugins/lens/common/expressions/datatable/datatable.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/datatable.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import type { ExpressionFunctionDefinition } from '../../../../../../src/plugins/expressions/common';
 import type { DatatableTransformerResult, DatatableTransformerArgs } from './datatable_transformer';
 
-export type DatatableProps = Omit<DatatableTransformerResult, 'type'> & {
+export type DatatableProps = Omit<DatatableTransformerResult, 'type' | 'columns'> & {
   args: DatatableArgs;
 };
 

--- a/x-pack/plugins/lens/common/expressions/datatable/datatable.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/datatable.ts
@@ -61,8 +61,8 @@ export const datatable: ExpressionFunctionDefinition<
       help: '',
     },
   },
-  fn(data, args, context) {
-    const [firstTable] = Object.values(data.data.tables);
+  fn({ data, untransposedData, columns }, args, context) {
+    const [firstTable] = Object.values(data.tables);
     const { sortingColumnId: sortBy, sortingDirection: sortDirection } = args;
 
     if (
@@ -77,10 +77,11 @@ export const datatable: ExpressionFunctionDefinition<
       type: 'render',
       as: 'lens_datatable_renderer',
       value: {
-        ...data,
+        data,
+        untransposedData,
         args: {
           ...args,
-          columns: data.columns,
+          columns,
         },
       },
     };

--- a/x-pack/plugins/lens/common/expressions/datatable/datatable_transformer.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/datatable_transformer.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cloneDeep } from 'lodash';
+import type {
+  DatatableColumnMeta,
+  ExpressionFunctionDefinition,
+} from '../../../../../../src/plugins/expressions/common';
+import type { FormatFactory, LensMultiTable } from '../../types';
+import { ColumnConfigArg } from './datatable_column';
+import { getSortingCriteria } from './sorting';
+import { computeSummaryRowForColumn } from './summary';
+import { transposeTable } from './transpose_helpers';
+
+export interface DatatableTransformerResult {
+  type: 'multiple_lens_multitable';
+  data: LensMultiTable;
+  untransposedData?: LensMultiTable;
+  columns: ColumnConfigArg[];
+}
+
+export interface DatatableTransformerArgs {
+  columns: ColumnConfigArg[];
+  sortingColumnId: string | undefined;
+  sortingDirection: 'asc' | 'desc' | 'none';
+}
+
+function isRange(meta: { params?: { id?: string } } | undefined) {
+  return meta?.params?.id === 'range';
+}
+
+export const getDatatableTransformer = ({
+  formatFactory,
+}: {
+  formatFactory: FormatFactory;
+}): ExpressionFunctionDefinition<
+  'lens_datatable_transformer',
+  LensMultiTable,
+  DatatableTransformerArgs,
+  DatatableTransformerResult
+> => ({
+  name: 'lens_datatable_transformer',
+  type: 'multiple_lens_multitable',
+  inputTypes: ['lens_multitable'],
+  help: '',
+  args: {
+    columns: {
+      types: ['lens_datatable_column'],
+      help: '',
+      multi: true,
+    },
+    sortingColumnId: {
+      types: ['string'],
+      help: '',
+    },
+    sortingDirection: {
+      types: ['string'],
+      help: '',
+    },
+  },
+  fn(data, args, context) {
+    let untransposedData: LensMultiTable | undefined;
+    // do the sorting at this level to propagate it also at CSV download
+    const [firstTable] = Object.values(data.tables);
+    const [layerId] = Object.keys(context.inspectorAdapters.tables || {});
+    const formatters: Record<string, ReturnType<FormatFactory>> = {};
+
+    firstTable.columns.forEach((column) => {
+      formatters[column.id] = formatFactory(column.meta?.params);
+    });
+
+    const hasTransposedColumns = args.columns.some((c) => c.isTransposed);
+    if (hasTransposedColumns) {
+      // store original shape of data separately
+      untransposedData = cloneDeep(data);
+      // transposes table and args inplace
+      transposeTable(args, firstTable, formatters);
+    }
+
+    const { sortingColumnId: sortBy, sortingDirection: sortDirection } = args;
+
+    const columnsReverseLookup = firstTable.columns.reduce<
+      Record<string, { name: string; index: number; meta?: DatatableColumnMeta }>
+    >((memo, { id, name, meta }, i) => {
+      memo[id] = { name, index: i, meta };
+      return memo;
+    }, {});
+
+    const columnsWithSummary = args.columns.filter((c) => c.summaryRow);
+    for (const column of columnsWithSummary) {
+      column.summaryRowValue = computeSummaryRowForColumn(
+        column,
+        firstTable,
+        formatters,
+        formatFactory({ id: 'number' })
+      );
+    }
+
+    if (sortBy && columnsReverseLookup[sortBy] && sortDirection !== 'none') {
+      // Sort on raw values for these types, while use the formatted value for the rest
+      const sortingCriteria = getSortingCriteria(
+        isRange(columnsReverseLookup[sortBy]?.meta)
+          ? 'range'
+          : columnsReverseLookup[sortBy]?.meta?.type,
+        sortBy,
+        formatters[sortBy],
+        sortDirection
+      );
+      // replace the table here
+      context.inspectorAdapters.tables[layerId].rows = (firstTable.rows || [])
+        .slice()
+        .sort(sortingCriteria);
+      // replace also the local copy
+      firstTable.rows = context.inspectorAdapters.tables[layerId].rows;
+    }
+    return {
+      type: 'multiple_lens_multitable',
+      data,
+      untransposedData,
+      // columns have been manipulated by transpose, so export new columns config
+      columns: args.columns,
+    };
+  },
+});

--- a/x-pack/plugins/lens/common/expressions/datatable/index.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './datatable_column';
+export * from './datatable_transformer';
 export * from './datatable';
 export * from './sorting';
 export * from './summary';

--- a/x-pack/plugins/lens/common/expressions/datatable/transpose_helpers.ts
+++ b/x-pack/plugins/lens/common/expressions/datatable/transpose_helpers.ts
@@ -46,7 +46,7 @@ export function getOriginalId(id: string) {
  * @param formatters Formatters for all columns to transpose columns by actual display values
  */
 export function transposeTable(
-  args: DatatableArgs,
+  args: Pick<DatatableArgs, 'columns'>,
   firstTable: Datatable,
   formatters: Record<string, FieldFormat>
 ) {
@@ -116,7 +116,7 @@ function transposeRows(
  * grouped by unique value
  */
 function updateColumnArgs(
-  args: DatatableArgs,
+  args: Pick<DatatableArgs, 'columns'>,
   bucketsColumnArgs: ColumnConfig['columns'],
   transposedColumnGroups: Array<ColumnConfig['columns']>
 ) {
@@ -154,7 +154,7 @@ function getUniqueValues(table: Datatable, formatter: FieldFormat, columnId: str
  * @param uniqueValues
  */
 function transposeColumns(
-  args: DatatableArgs,
+  args: Pick<DatatableArgs, 'columns'>,
   bucketsColumnArgs: ColumnConfig['columns'],
   metricColumns: ColumnConfig['columns'],
   firstTable: Datatable,

--- a/x-pack/plugins/lens/public/datatable_visualization/datatable_visualization.ts
+++ b/x-pack/plugins/lens/public/datatable_visualization/datatable_visualization.ts
@@ -5,6 +5,6 @@
  * 2.0.
  */
 
-export { datatableColumn, getDatatable } from '../../common/expressions';
+export { datatableColumn, getDatatableTransformer, datatable } from '../../common/expressions';
 export * from './expression';
 export * from './visualization';

--- a/x-pack/plugins/lens/public/datatable_visualization/expression.test.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/expression.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getDatatable, DatatableProps } from '../../common/expressions';
+import { datatable, getDatatableTransformer, DatatableProps } from '../../common/expressions';
 import type { LensMultiTable } from '../../common';
 import { createMockExecutionContext } from '../../../../../src/plugins/expressions/common/mocks';
 import { IFieldFormat } from '../../../../../src/plugins/data/public';
@@ -84,11 +84,13 @@ describe('datatable_expression', () => {
   describe('datatable renders', () => {
     test('it renders with the specified data and args', () => {
       const { data, args } = sampleArgs();
-      const result = getDatatable({ formatFactory: (x) => x as IFieldFormat }).fn(
+      const dataProcessed = getDatatableTransformer({ formatFactory: (x) => x as IFieldFormat }).fn(
         data,
         args,
         createMockExecutionContext()
       );
+
+      const result = datatable.fn(dataProcessed, args, createMockExecutionContext());
 
       expect(result).toEqual({
         type: 'render',

--- a/x-pack/plugins/lens/public/datatable_visualization/index.ts
+++ b/x-pack/plugins/lens/public/datatable_visualization/index.ts
@@ -31,7 +31,8 @@ export class DatatableVisualization {
   ) {
     editorFrame.registerVisualization(async () => {
       const {
-        getDatatable,
+        datatable,
+        getDatatableTransformer,
         datatableColumn,
         getDatatableRenderer,
         getDatatableVisualization,
@@ -40,7 +41,10 @@ export class DatatableVisualization {
       const resolvedFormatFactory = await formatFactory;
 
       expressions.registerFunction(() => datatableColumn);
-      expressions.registerFunction(() => getDatatable({ formatFactory: resolvedFormatFactory }));
+      expressions.registerFunction(() => datatable);
+      expressions.registerFunction(() =>
+        getDatatableTransformer({ formatFactory: resolvedFormatFactory })
+      );
       expressions.registerRenderer(() =>
         getDatatableRenderer({
           formatFactory: resolvedFormatFactory,

--- a/x-pack/plugins/lens/public/datatable_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/visualization.tsx
@@ -320,15 +320,18 @@ export const getDatatableVisualization = ({
       .filter((columnId) => datasource!.getOperationForColumnId(columnId))
       .map((columnId) => columnMap[columnId]);
 
+    const columnArgs = {
+      sortingColumnId: [state.sorting?.columnId || ''],
+      sortingDirection: [state.sorting?.direction || 'none'],
+    };
+
     return {
       type: 'expression',
       chain: [
         {
           type: 'function',
-          function: 'lens_datatable',
+          function: 'lens_datatable_transformer',
           arguments: {
-            title: [title || ''],
-            description: [description || ''],
             columns: columns.map((column) => {
               const paletteParams = {
                 ...column.palette?.params,
@@ -344,10 +347,10 @@ export const getDatatableVisualization = ({
               const hasNoSummaryRow = column.summaryRow == null || column.summaryRow === 'none';
 
               return {
-                type: 'expression',
+                type: 'expression' as const,
                 chain: [
                   {
-                    type: 'function',
+                    type: 'function' as const,
                     function: 'lens_datatable_column',
                     arguments: {
                       columnId: [column.columnId],
@@ -370,8 +373,16 @@ export const getDatatableVisualization = ({
                 ],
               };
             }),
-            sortingColumnId: [state.sorting?.columnId || ''],
-            sortingDirection: [state.sorting?.direction || 'none'],
+            ...columnArgs,
+          },
+        },
+        {
+          type: 'function',
+          function: 'lens_datatable',
+          arguments: {
+            title: [title || ''],
+            description: [description || ''],
+            ...columnArgs,
           },
         },
       ],


### PR DESCRIPTION
## Summary

Branch built on top of https://github.com/elastic/kibana/pull/105455 . This PR has been created to make it easier to diff the two.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
