### PR TITLE
[Lens] Refactor Flyout Design Updates

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.scss
@@ -5,19 +5,15 @@
   // Use the EuiFlyout style
   @include euiFlyout;
   // But with custom positioning to keep it within the sidebar contents
-  position: absolute;
-  left: 0;
   animation: euiFlyout $euiAnimSpeedNormal $euiAnimSlightResistance;
+  left: 0;
+  max-width: none !important;
+  z-index: $euiZContentMenu;
 
   @include euiBreakpoint('l', 'xl') {
-    top: 0 !important;
     height: 100% !important;
-  }
-
-  @include euiBreakpoint('xs', 's', 'm') {
-    @include euiFlyout;
-    left: 10vw;
-    z-index: $euiZContentMenu;
+    position: absolute;
+    top: 0 !important;
   }
 
   .lnsFrameLayout__sidebar-isFullscreen & {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -317,12 +317,7 @@ export function LayerPanel(
 
   return (
     <>
-      <section
-        tabIndex={-1}
-        ref={registerLayerRef}
-        className="lnsLayerPanel"
-        style={{ visibility: isDimensionPanelOpen ? 'hidden' : 'visible' }}
-      >
+      <section tabIndex={-1} ref={registerLayerRef} className="lnsLayerPanel">
         <EuiPanel data-test-subj={`lns-layerPanel-${layerIndex}`} paddingSize="none">
           <header className="lnsLayerPanel__layerHeader">
             <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">


### PR DESCRIPTION
Hey, @dej611. This is a little design PR that performs the similar task of fixing the broken Lens configuration flyout at small viewport sizes, but with some slightly reorganized CSS. It also removes the flyout's `max-width` styles, which allows it to go full width at small viewport sizes (which I think looks better and allows users to better focus on the configuration task on small devices). Finally, it removes some `visibility` styles that it looks like Wylie had applied to the layer panel when a configuration flyout is open. Not sure why those styles where put in place, but their removal didn't appear to break anything and it prevented the odd flashing disappearance of the layer panel that can be seen when the flyout animation is triggered.

![image](https://user-images.githubusercontent.com/3884767/144633121-ce2e46c6-354a-4655-a3c1-b049abb7e003.png)