### PR TITLE
[One Workflow] Redesign zoom controls and fix switch-step graph rendering

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_bottom_bar.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_bottom_bar.tsx
@@ -17,7 +17,6 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import type { CSSObject } from '@emotion/react';
-import { useReactFlow, useStore } from '@xyflow/react';
 import React, {
   createContext,
   type ReactNode,
@@ -95,146 +94,6 @@ const TOGGLE_ACTIVE_SHADOW =
 // to the compact "…" pill. Chosen to give the full bar enough room before it
 // starts overlapping the minimap (bottom-left of the canvas).
 const COMPACT_THRESHOLD_PX = 800;
-
-function ZoomControls() {
-  const zoomOutLabel = i18n.translate('workflowsUi.bottomBar.zoomOut', {
-    defaultMessage: 'Zoom out',
-  });
-  const zoomInLabel = i18n.translate('workflowsUi.bottomBar.zoomIn', {
-    defaultMessage: 'Zoom in',
-  });
-
-  const { zoomIn, zoomOut } = useReactFlow();
-  const handleZoomOut = useCallback(() => zoomOut({ duration: 200 }), [zoomOut]);
-  const handleZoomIn = useCallback(() => zoomIn({ duration: 200 }), [zoomIn]);
-
-  return (
-    <>
-      <EuiFlexItem grow={false}>
-        <EuiToolTip content={zoomInLabel} disableScreenReaderOutput>
-          <EuiButtonIcon
-            iconType="plusInCircle"
-            aria-label={zoomInLabel}
-            color="text"
-            size="s"
-            onClick={handleZoomIn}
-            data-test-subj="workflowBottomBar-zoom-in"
-          />
-        </EuiToolTip>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiToolTip content={zoomOutLabel} disableScreenReaderOutput>
-          <EuiButtonIcon
-            iconType="minusInCircle"
-            aria-label={zoomOutLabel}
-            color="text"
-            size="s"
-            onClick={handleZoomOut}
-            data-test-subj="workflowBottomBar-zoom-out"
-          />
-        </EuiToolTip>
-      </EuiFlexItem>
-    </>
-  );
-}
-
-// Treat any zoom within this tolerance of 1.0 as "default" (not zoomed).
-const ZOOM_RESET_EPS = 0.01;
-
-// Visual width of the pill, of which 12px tucks behind the bar via z-index.
-const ZOOM_RESET_PILL_WIDTH = 64;
-const ZOOM_RESET_PILL_OVERLAP = 12;
-
-/**
- * Yellow bullseye pill that slides out from under the left edge of the bar
- * whenever the graph is zoomed. Click to reset to zoom = 1. Sits at a lower
- * z-index than the bar so its right edge tucks under (and is hidden by) the
- * bar's solid background.
- */
-function ZoomResetPill({
-  editorView,
-  isExpanded,
-  onMouseEnter,
-  onMouseLeave,
-}: {
-  editorView: WorkflowDetailBottomBarView;
-  isExpanded: boolean;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
-}) {
-  const { euiTheme } = useEuiTheme();
-  const zoom = useStore((s) => s.transform[2]);
-  const isZoomed = Math.abs(zoom - 1) > ZOOM_RESET_EPS;
-  const { setViewport, getViewport } = useReactFlow();
-
-  const handleReset = useCallback(() => {
-    const { x, y } = getViewport();
-    setViewport({ x, y, zoom: 1 }, { duration: 200 });
-  }, [getViewport, setViewport]);
-
-  const show = editorView === 'graph' && isZoomed && isExpanded;
-  const label = i18n.translate('workflowsUi.bottomBar.zoomReset', {
-    defaultMessage: 'Reset zoom',
-  });
-
-  return (
-    <div
-      role="button"
-      tabIndex={show ? 0 : -1}
-      aria-label={label}
-      title={label}
-      data-test-subj="workflowBottomBar-zoom-reset"
-      onClick={handleReset}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleReset();
-        }
-      }}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      aria-hidden={!show}
-      css={{
-        position: 'absolute',
-        right: '100%',
-        top: 0,
-        bottom: 0,
-        width: ZOOM_RESET_PILL_WIDTH,
-        transform: show
-          ? `translateX(${ZOOM_RESET_PILL_OVERLAP}px)`
-          : `translateX(${ZOOM_RESET_PILL_WIDTH}px)`,
-        opacity: show ? 1 : 0,
-        pointerEvents: show ? 'auto' : 'none',
-        transition:
-          'transform 300ms cubic-bezier(0.4, 0, 0.2, 1), opacity 200ms ease, filter 120ms ease',
-        zIndex: 0,
-        background: '#fde9b5',
-        // Only the left side is rounded; the right side stays square and tucks
-        // under the bar (Figma rectangleCornerRadii [10, 0, 0, 10]).
-        borderTopLeftRadius: 10,
-        borderBottomLeftRadius: 10,
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-        boxShadow: BAR_SHADOW,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-start',
-        // Centers the 16px icon within the visible 52px portion of the pill
-        // (visible = ZOOM_RESET_PILL_WIDTH - ZOOM_RESET_PILL_OVERLAP = 52,
-        //  (52 - 16) / 2 = 18).
-        paddingLeft: 18,
-        cursor: 'pointer',
-        '&:hover': { filter: 'brightness(0.97)' },
-        '&:focus-visible': {
-          outline: `2px solid ${euiTheme.colors.primary}`,
-          outlineOffset: 2,
-        },
-      }}
-    >
-      <EuiIcon type="bullseye" size="m" color="#1d2a3e" aria-hidden />
-    </div>
-  );
-}
 
 function ViewToggle({
   editorView,
@@ -516,15 +375,6 @@ export function WorkflowDetailBottomBar({
   return (
     <WorkflowBottomBarContext.Provider value={{ isExpanded }}>
       <div ref={containerRef} css={barCss} data-test-subj="workflowDetailBottomBar">
-        {/* Wrapper provides the positioning context the ZoomResetPill anchors to
-            (right: 100% of this wrapper = left edge of the inner bar). */}
-        <div css={{ position: 'relative', pointerEvents: 'none' }}>
-        <ZoomResetPill
-          editorView={editorView}
-          isExpanded={isExpanded}
-          onMouseEnter={handleExpandedMouseEnter}
-          onMouseLeave={handleExpandedMouseLeave}
-        />
         <div
           css={{
             pointerEvents: isExpanded ? 'auto' : 'none',
@@ -545,56 +395,15 @@ export function WorkflowDetailBottomBar({
           onMouseLeave={handleExpandedMouseLeave}
         >
         <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center" wrap={false}>
-          {/* Left section — cross-fades between zoom (graph) and yaml actions
-              (yaml). Both variants live in the same grid cell so layout stays
-              stable across the 200ms opacity transition. */}
-          <EuiFlexItem grow={false}>
-            <div
-              css={{
-                display: 'grid',
-                gridTemplateAreas: '"stack"',
-                alignItems: 'center',
-              }}
-            >
-              <div
-                css={{
-                  gridArea: 'stack',
-                  display: 'flex',
-                  alignItems: 'center',
-                  opacity: editorView === 'graph' ? 1 : 0,
-                  pointerEvents: editorView === 'graph' ? 'auto' : 'none',
-                  transition: 'opacity 200ms ease',
-                }}
-                aria-hidden={editorView !== 'graph'}
-              >
-                <EuiFlexGroup
-                  gutterSize="none"
-                  responsive={false}
-                  alignItems="center"
-                  wrap={false}
-                >
-                  <ZoomControls />
-                </EuiFlexGroup>
-              </div>
-              <div
-                css={{
-                  gridArea: 'stack',
-                  display: 'flex',
-                  alignItems: 'center',
-                  opacity: editorView === 'yaml' ? 1 : 0,
-                  pointerEvents: editorView === 'yaml' ? 'auto' : 'none',
-                  transition: 'opacity 200ms ease',
-                }}
-                aria-hidden={editorView !== 'yaml'}
-              >
-                {yamlActionsSlot}
-              </div>
-            </div>
-          </EuiFlexItem>
-
-          <EuiFlexItem grow={false}>
-            <VerticalDivider />
-          </EuiFlexItem>
+          {/* Left section — yaml actions slot, only shown in yaml view. */}
+          {yamlActionsSlot && editorView === 'yaml' ? (
+            <>
+              <EuiFlexItem grow={false}>{yamlActionsSlot}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <VerticalDivider />
+              </EuiFlexItem>
+            </>
+          ) : null}
 
           {compact ? (
             <EuiFlexItem grow={false}>
@@ -628,7 +437,6 @@ export function WorkflowDetailBottomBar({
           ) : null}
         </EuiFlexGroup>
         </div>
-      </div>
 
       {/* Collapsed pill — hover to expand */}
       <div

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_canvas.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_canvas.tsx
@@ -7,16 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiCallOut, useEuiTheme } from '@elastic/eui';
+import { EuiButtonIcon, EuiCallOut, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import {
   Background,
   type ColorMode,
   type EdgeTypes,
   MiniMap,
   type NodeTypes,
+  Panel,
   ReactFlow,
   type ReactFlowInstance,
   ReactFlowProvider,
+  useReactFlow,
   type Viewport,
 } from '@xyflow/react';
 import React, { Component, type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -88,6 +90,78 @@ const PRO_OPTIONS = { hideAttribution: true } as const;
 const INITIAL_ZOOM = 1;
 const TOP_PADDING = 80;
 
+const CANVAS_CONTROLS_SHADOW =
+  '0 0 2px 0 rgba(43, 57, 79, 0.16), 0 1px 4px 0 rgba(43, 57, 79, 0.06), 0 2px 8px 0 rgba(43, 57, 79, 0.05)';
+
+function CanvasZoomControls() {
+  const { euiTheme } = useEuiTheme();
+  const { zoomIn, zoomOut, getViewport, setViewport } = useReactFlow();
+
+  const zoomOutLabel = i18n.translate('workflowsUi.graph.zoomOut', {
+    defaultMessage: 'Zoom out',
+  });
+  const zoomInLabel = i18n.translate('workflowsUi.graph.zoomIn', {
+    defaultMessage: 'Zoom in',
+  });
+  const resetZoomLabel = i18n.translate('workflowsUi.graph.resetZoom', {
+    defaultMessage: 'Reset zoom',
+  });
+
+  const handleZoomOut = useCallback(() => zoomOut({ duration: 200 }), [zoomOut]);
+  const handleZoomIn = useCallback(() => zoomIn({ duration: 200 }), [zoomIn]);
+  const handleResetZoom = useCallback(() => {
+    const { x, y } = getViewport();
+    setViewport({ x, y, zoom: 1 }, { duration: 200 });
+  }, [getViewport, setViewport]);
+
+  return (
+    <Panel position="bottom-right" style={{ margin: 12 }}>
+      <div
+        css={{
+          background: euiTheme.colors.backgroundBasePlain,
+          borderRadius: 8,
+          boxShadow: CANVAS_CONTROLS_SHADOW,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 4,
+          gap: 2,
+        }}
+      >
+        <EuiToolTip content={zoomOutLabel} position="left" disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="minusInCircle"
+            aria-label={zoomOutLabel}
+            color="text"
+            size="s"
+            onClick={handleZoomOut}
+            data-test-subj="workflowCanvas-zoom-out"
+          />
+        </EuiToolTip>
+        <EuiToolTip content={zoomInLabel} position="left" disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="plusInCircle"
+            aria-label={zoomInLabel}
+            color="text"
+            size="s"
+            onClick={handleZoomIn}
+            data-test-subj="workflowCanvas-zoom-in"
+          />
+        </EuiToolTip>
+        <EuiToolTip content={resetZoomLabel} position="left" disableScreenReaderOutput>
+          <EuiButtonIcon
+            iconType="bullseye"
+            aria-label={resetZoomLabel}
+            color="text"
+            size="s"
+            onClick={handleResetZoom}
+            data-test-subj="workflowCanvas-reset-zoom"
+          />
+        </EuiToolTip>
+      </div>
+    </Panel>
+  );
+}
+
 export interface WorkflowGraphCanvasProps {
   readonly workflow: WorkflowYaml | undefined;
   /** Optional precomputed transform result for this workflow snapshot. */
@@ -134,6 +208,8 @@ export interface WorkflowGraphCanvasProps {
   };
   /** Whether to render the minimap. Pass false to suppress it (e.g. for exports). */
   readonly showMinimap?: boolean;
+  /** Whether to render the floating zoom controls in the bottom-right corner. */
+  readonly showZoomControls?: boolean;
   /**
    * Whether to render the dot-pattern background and the coloured wrapper div
    * background. Pass false for export canvases that need a transparent output.
@@ -187,6 +263,7 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
     fitView: fitViewProp = false,
     fitViewOptions: fitViewOptionsProp,
     showMinimap = true,
+    showZoomControls = false,
     showBackground = true,
     edgeZIndex = -1,
     onReady,
@@ -491,6 +568,7 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
                 />
               )}
               {toolbar}
+              {showZoomControls && <CanvasZoomControls />}
               {showMinimap && (
                 <MiniMap
                   pannable

--- a/src/platform/packages/shared/kbn-workflows/graph_layout/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph_layout/index.ts
@@ -10,6 +10,8 @@
 export {
   DEFAULT_NODE_STYLE,
   FLOW_CONTROL_STEP_TYPES,
+  SWITCH_DEFAULT_HANDLE,
+  switchCaseHandleId,
   TRIGGER_STEP_TYPES,
   type EdgeBranchType,
   type ForeachGroup,

--- a/src/platform/packages/shared/kbn-workflows/graph_layout/types.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph_layout/types.ts
@@ -113,6 +113,9 @@ export interface LayoutedNode extends PreLayoutNodeBase {
   sourcePosition?: HandleSide;
 }
 
+export const SWITCH_DEFAULT_HANDLE = 'switch-default' as const;
+export const switchCaseHandleId = (index: number): string => `switch-case-${index}`;
+
 export function isStep(value: unknown): value is Step {
   if (typeof value !== 'object' || value === null) return false;
   const record = value as Record<string, unknown>;

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/middleware.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/middleware.ts
@@ -9,22 +9,31 @@
 
 import type { AnyAction, Dispatch, Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
 import { debounce } from 'lodash';
+import type { WorkflowYaml } from '@kbn/workflows';
 import { _clearComputedData, _setComputedDataInternal, setYamlString } from './slice';
 import { performComputation } from './utils/computation';
 import type { RootState } from '../types';
 
 const COMPUTATION_DEBOUNCE_MS = 500;
 
-const compute = (yamlString: string, store: MiddlewareAPI<Dispatch<AnyAction>, RootState>) => {
+const compute = (
+  yamlString: string,
+  store: MiddlewareAPI<Dispatch<AnyAction>, RootState>,
+  loadedDefinition?: WorkflowYaml
+) => {
   try {
-    const computed = performComputation(yamlString);
+    const computed = performComputation(yamlString, loadedDefinition);
     store.dispatch(_setComputedDataInternal(computed));
   } catch (e) {
     store.dispatch(_clearComputedData());
   }
 };
 
-const debouncedCompute = debounce(compute, COMPUTATION_DEBOUNCE_MS);
+const debouncedCompute = debounce(
+  (yamlString: string, store: MiddlewareAPI<Dispatch<AnyAction>, RootState>) =>
+    compute(yamlString, store),
+  COMPUTATION_DEBOUNCE_MS
+);
 
 // Side effects middleware - computes derived data when yamlString changes (debounced)
 const workflowComputationMiddleware: Middleware =
@@ -46,7 +55,11 @@ const workflowComputationMiddleware: Middleware =
 
       // Do computation immediately if not initialized yet, (computed is only undefined when never set)
       if (!computed) {
-        compute(yamlString, store);
+        // On initial load pass the server-parsed definition so the graph renders
+        // even when the client-side YAML parser can't handle the workflow's syntax.
+        const loadedDefinition =
+          store.getState().detail.workflow?.definition ?? undefined;
+        compute(yamlString, store, loadedDefinition);
       } else {
         debouncedCompute(yamlString, store);
       }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_visual_editor/ui/workflow_visual_editor_stateful.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_visual_editor/ui/workflow_visual_editor_stateful.tsx
@@ -245,6 +245,7 @@ export const WorkflowVisualEditorStateful: React.FC<WorkflowVisualEditorStateful
         canRunSteps={Boolean(canExecuteWorkflow) && isYamlValid}
         defaultViewport={defaultViewport}
         onViewportChange={onViewportChange}
+        showZoomControls
       />
       {flyoutTarget && (
         <EuiFocusTrap returnFocus>


### PR DESCRIPTION
## Summary

- Moved zoom +/- and reset controls from the bottom bar into a floating `Panel` (ReactFlow) at the bottom-right corner of the canvas (`workflow_graph_canvas.tsx`). The reset button uses a bullseye icon and resets zoom to 100% while preserving pan position.
- Eliminated the empty whitespace on the left side of the bottom bar in graph view — the yaml-actions slot now only renders when `editorView === 'yaml'`.
- Fixed a `TypeError: switchCaseHandleId is not a function` crash that caused a blank screen for workflows with `switch` steps (e.g. `sources-github-search`). The `SWITCH_DEFAULT_HANDLE` constant and `switchCaseHandleId` function were referenced in `transform_workflow_to_graph.ts` but never defined; added them to `graph_layout/types.ts` and re-exported from `graph_layout/index.ts`.
- On initial YAML load the middleware now passes the server-parsed definition as a fallback to `performComputation`, so the graph renders even when the client-side YAML parser can't handle the workflow's syntax.

## Test plan

- [ ] Open a workflow — graph view renders without errors
- [ ] Zoom in/out with the floating bottom-right controls; reset snaps back to 100%
- [ ] Bottom bar shows no left-side whitespace in graph view; yaml-actions slot appears normally in YAML view
- [ ] Open `sources-github-search` workflow in graph view — no blank screen / console error
- [ ] Toggle between graph and YAML views — both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)